### PR TITLE
UI fixes (#117)

### DIFF
--- a/lib/Screens/home_page.dart
+++ b/lib/Screens/home_page.dart
@@ -33,7 +33,9 @@ class _HomePageState extends State<HomePage> {
             const CustomAppBar(),
             const SizedBox(
               height: 30,
+
             ),
+
             Text(
               'Choose one of the following options by tapping with fingers.',
               style: GoogleFonts.oswald(

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -3,27 +3,29 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:remar_flutter_app/utils/color_res.dart';
 
 class CustomAppBar extends StatelessWidget {
-  const CustomAppBar({super.key});
+  const CustomAppBar({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final double imageHeight = constraints.maxHeight > 40 ? 40 : constraints.maxHeight;
-        return Column(
-          children: [
-            Container(
-              padding: const EdgeInsets.only(right: 10, left: 10),
+    return AppBar(
+      automaticallyImplyLeading: false,
+      title: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return Container(
+              padding: const EdgeInsets.only(right: 15, left: 15),
               width: double.infinity,
               decoration: const BoxDecoration(
-                  border: Border(
-                      bottom: BorderSide(color: ColorRes.greenColor, width: 5))),
+                border: Border(
+                  bottom: BorderSide(color: ColorRes.greenColor, width: 5),
+                ),
+              ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Expanded(
-                    child: Container(
-                      height: 40,
+                    child: SizedBox(
+                      height: 50,
                       child: RichText(
                         text: TextSpan(
                           children: [
@@ -31,7 +33,7 @@ class CustomAppBar extends StatelessWidget {
                               text: "REMAR",
                               style: GoogleFonts.oswald(
                                 color: Colors.black,
-                                fontSize: 30.0,
+                                fontSize: 25.0,
                                 fontWeight: FontWeight.w900,
                               ),
                             ),
@@ -39,7 +41,7 @@ class CustomAppBar extends StatelessWidget {
                               text: "_CITIZEN",
                               style: GoogleFonts.oswald(
                                 color: Colors.black,
-                                fontSize: 24.0,
+                                fontSize: 18.0,
                                 fontWeight: FontWeight.w300,
                               ),
                             )
@@ -52,22 +54,24 @@ class CustomAppBar extends StatelessWidget {
                     children: [
                       Image.asset(
                         'assets/images/raster_logo_ufsb.png',
-                        height: imageHeight,
-                        fit: BoxFit.contain,
+                        height: MediaQuery.of(context).size.height * 0.05,
+                        width: MediaQuery.of(context).size.width * 0.07,
                       ),
                       Image.asset(
                         "assets/images/raster_logo_napier.png",
-                        height: imageHeight,
-                        fit: BoxFit.contain,
+                        height: 50,
+                        width: 70,
                       ),
                     ],
                   )
                 ],
               ),
-            ),
-          ],
-        );
-      },
+            );
+          },
+        ),
+      ),
     );
   }
 }
+
+


### PR DESCRIPTION
* Changed app_bar.dart to use AppBar widget and wrapped around SafeArea to prevent app bar from clashing with system icons. Tested with Samsung A13 device

* Changed app_bar.dart to use AppBar widget and wrapped around SafeArea to prevent app bar from clashing with system icons. Tested with Pixel 7 emulator

---------